### PR TITLE
Improve theme toggle and song toolbar

### DIFF
--- a/performance/performance.html
+++ b/performance/performance.html
@@ -23,7 +23,7 @@
 	    <span id="font-size-display" style="min-width:2.2em;text-align:center;font-size:1.03em;">32px</span>
 	    <button id="increase-font-btn" class="icon-btn" title="Larger Font"><i class="fas fa-plus"></i></button>
 	    <button id="autoscroll-settings-btn" class="icon-btn" title="Autoscroll Settings"><i class="fas fa-cog"></i></button>
-	    <button id="toggle-theme-btn" class="icon-btn" title="Toggle Theme"><i class="fas fa-adjust"></i></button>
+            <button id="theme-toggle-btn" class="icon-btn" title="Toggle Theme"><i class="fas fa-adjust"></i></button>
 	    <button id="exit-performance-btn" class="icon-btn danger" title="Exit Performance"><i class="fas fa-times"></i></button>
 	</div>
         </div>

--- a/performance/performance.js
+++ b/performance/performance.js
@@ -7,7 +7,7 @@ document.addEventListener('DOMContentLoaded', () => {
         decreaseFontBtn: document.getElementById('decrease-font-btn'),
         increaseFontBtn: document.getElementById('increase-font-btn'),
         fontSizeDisplay: document.getElementById('font-size-display'),
-        toggleThemeBtn: document.getElementById('toggle-theme-btn'),
+        toggleThemeBtn: document.getElementById('theme-toggle-btn'),
         exitPerformanceBtn: document.getElementById('exit-performance-btn'),
         prevSongBtn: document.getElementById('prev-song-btn'),
         nextSongBtn: document.getElementById('next-song-btn'),

--- a/script.js
+++ b/script.js
@@ -304,9 +304,11 @@ document.addEventListener('DOMContentLoaded', () => {
         tabToolbars: {
             songs: `
                 <input type="text" id="song-search-input" class="search-input" placeholder="Search songs...">
-                <button id="add-song-btn" class="btn"><i class="fas fa-plus"></i></button>
-                <button id="delete-all-songs-btn" class="btn danger"><i class="fas fa-trash"></i></button>
-                <label for="song-upload-input" class="btn"><i class="fas fa-upload"></i></label>
+                <div class="toolbar-buttons-group">
+                    <button id="add-song-btn" class="btn"><i class="fas fa-plus"></i></button>
+                    <button id="delete-all-songs-btn" class="btn danger"><i class="fas fa-trash"></i></button>
+                    <label for="song-upload-input" class="btn"><i class="fas fa-upload"></i></label>
+                </div>
                 <input type="file" id="song-upload-input" multiple accept=".txt,.docx" class="hidden-file">
             `,
             setlists: `


### PR DESCRIPTION
## Summary
- ensure performance mode theme toggle uses same button id
- group song toolbar buttons so they align horizontally

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6877eb8c776c832ab6578f7f9d48c237