### PR TITLE
feat: performance editing and metadata

### DIFF
--- a/performance/performance.css
+++ b/performance/performance.css
@@ -289,3 +289,31 @@
     font-size: 1rem;
    }
 }
+
+.modal-content .modal-row {
+  display: flex; align-items: center; gap: 0.5rem;
+  margin: 0.4rem 0;
+}
+.modal-content .modal-row > label { min-width: 9em; }
+.modal-content select, .modal-content input, .modal-content textarea {
+  width: 100%;
+  background: var(--bg-tertiary); color: var(--text-primary);
+  border: 1px solid var(--border); border-radius: 10px; padding: 0.5rem;
+}
+.metadata-row { display: flex; gap: 0.6rem; align-items: center; margin: 0.4rem 0; }
+.metadata-row > label { min-width: 9em; }
+.meta-actions { display: flex; gap: 0.6rem; justify-content: flex-end; margin-top: 0.8rem; }
+
+/* Compact metadata line under title */
+.performance-header .song-meta-line {
+  font-size: 0.95em; color: var(--accent-secondary, #aaa); margin-top: 0.15em;
+  letter-spacing: 0.02em;
+}
+.performance-header .song-meta-line .notes-icon {
+  margin-left: 0.4em; cursor: pointer; opacity: 0.85;
+}
+.performance-header .song-meta-line .notes-icon:hover { opacity: 1; }
+
+.lyrics-line-group { margin-bottom: 0.35em; }
+.chord-line { white-space: pre; font-size: 0.85em; color: var(--accent-secondary, #ccc); }
+.section-label { margin-top: 0.6em; font-weight: bold; }

--- a/performance/performance.html
+++ b/performance/performance.html
@@ -23,10 +23,13 @@
 	    <button id="decrease-font-btn" class="icon-btn" title="Smaller Font"><i class="fas fa-minus"></i></button>
 	    <span id="font-size-display" style="min-width:2.2em;text-align:center;font-size:1.03em;">32px</span>
 	    <button id="increase-font-btn" class="icon-btn" title="Larger Font"><i class="fas fa-plus"></i></button>
-	    <button id="autoscroll-settings-btn" class="icon-btn" title="Autoscroll Settings"><i class="fas fa-cog"></i></button>
+            <button id="autoscroll-settings-btn" class="icon-btn" title="Autoscroll Settings"><i class="fas fa-cog"></i></button>
+            <button id="perf-menu-btn" class="icon-btn" title="Performance Menu">
+              <i class="fas fa-ellipsis-h"></i>
+            </button>
             <button id="theme-toggle-btn" class="icon-btn theme-toggle-btn" title="Toggle Theme"><i class="fas fa-adjust"></i></button>
-	    <button id="exit-performance-btn" class="icon-btn danger" title="Exit Performance"><i class="fas fa-times"></i></button>
-	</div>
+            <button id="exit-performance-btn" class="icon-btn danger" title="Exit Performance"><i class="fas fa-times"></i></button>
+        </div>
         </div>
         <div id="lyrics-display" class="lyrics-container"></div>
         
@@ -46,8 +49,91 @@
     <!-- Floating buttons go here, outside the modal but inside <body> -->
     <button id="scroll-to-top-btn" class="scroll-to-top-btn"><i class="fas fa-arrow-up"></i></button>
     <button id="auto-scroll-btn" class="auto-scroll-btn"><i class="fas fa-angle-double-down"></i></button>
-   
 
+
+    <!-- Performance Menu Modal -->
+    <div id="performance-menu-modal" class="modal" style="display:none;">
+      <div class="modal-content">
+        <h2>Performance Options</h2>
+
+        <div class="modal-row">
+          <label for="perf-edit-mode"><i class="fas fa-edit"></i> Edit Mode</label>
+          <select id="perf-edit-mode">
+            <option value="readonly">Read Only</option>
+            <option value="lyrics">Lyrics Only</option>
+            <option value="chords">Chords Only</option>
+            <option value="both">Both</option>
+          </select>
+        </div>
+
+        <div class="modal-row">
+          <label for="perf-chord-mode"><i class="fas fa-guitar"></i> Chord Mode</label>
+          <select id="perf-chord-mode">
+            <option value="off">Off</option>
+            <option value="lyrics">Lyrics Only</option>
+            <option value="chords">Chords Only</option>
+            <option value="both" selected>Both</option>
+          </select>
+        </div>
+
+        <div class="modal-row">
+          <button id="perf-normalize-btn" class="btn"><i class="fas fa-broom"></i> Normalize Lyrics</button>
+        </div>
+
+        <div class="modal-row">
+          <button id="perf-metadata-btn" class="btn"><i class="fas fa-info-circle"></i> Song Info</button>
+        </div>
+
+        <button id="perf-menu-close" class="btn"><i class="fas fa-times"></i> Close</button>
+      </div>
+    </div>
+
+    <!-- Metadata Panel/Modal -->
+    <div id="perf-metadata-modal" class="modal" style="display:none;">
+      <div class="modal-content">
+        <h2>Song Information</h2>
+
+        <div class="metadata-row">
+          <label for="perf-key">Key:</label>
+          <select id="perf-key">
+            <option value="">Select Key</option>
+            <option>C</option><option>C#</option><option>D</option><option>D#</option>
+            <option>E</option><option>F</option><option>F#</option><option>G</option>
+            <option>G#</option><option>A</option><option>A#</option><option>B</option>
+          </select>
+        </div>
+
+        <div class="metadata-row">
+          <label for="perf-tempo">Tempo (BPM):</label>
+          <input type="number" id="perf-tempo" min="40" max="260">
+        </div>
+
+        <div class="metadata-row">
+          <label for="perf-ts">Time Signature:</label>
+          <select id="perf-ts">
+            <option>4/4</option><option>3/4</option><option>2/4</option>
+            <option>6/8</option><option>12/8</option>
+          </select>
+        </div>
+
+        <div class="metadata-row">
+          <label for="perf-tags">Tags:</label>
+          <input type="text" id="perf-tags" placeholder="rock, ballad, easy">
+        </div>
+
+        <div class="metadata-row">
+          <label for="perf-notes">Performance Notes:</label>
+          <textarea id="perf-notes" rows="4" placeholder="Cues, capo, structure, etc."></textarea>
+        </div>
+
+        <div class="meta-actions">
+          <button id="perf-metadata-save" class="btn"><i class="fas fa-save"></i> Save</button>
+          <button id="perf-metadata-close" class="btn"><i class="fas fa-times"></i> Close</button>
+        </div>
+      </div>
+    </div>
+
+    
     <script src="../lib/fuse.js"></script>
     <script src="../lib/idb.min.js"></script>
     <script src="../lib/mammoth.browser.min.js"></script>

--- a/performance/performance.js
+++ b/performance/performance.js
@@ -21,6 +21,22 @@ document.addEventListener('DOMContentLoaded', () => {
         autoscrollSpeedValue: document.getElementById('autoscroll-speed-value'),
         closeAutoscrollDelayModal: document.getElementById('close-autoscroll-delay-modal'),
 
+        perfMenuBtn: document.getElementById('perf-menu-btn'),
+        perfMenuModal: document.getElementById('performance-menu-modal'),
+        perfMenuClose: document.getElementById('perf-menu-close'),
+        perfEditModeSelect: document.getElementById('perf-edit-mode'),
+        perfChordModeSelect: document.getElementById('perf-chord-mode'),
+        perfNormalizeBtn: document.getElementById('perf-normalize-btn'),
+        perfMetadataBtn: document.getElementById('perf-metadata-btn'),
+        perfMetadataModal: document.getElementById('perf-metadata-modal'),
+        perfMetadataSave: document.getElementById('perf-metadata-save'),
+        perfMetadataClose: document.getElementById('perf-metadata-close'),
+        perfKey: document.getElementById('perf-key'),
+        perfTempo: document.getElementById('perf-tempo'),
+        perfTS: document.getElementById('perf-ts'),
+        perfTags: document.getElementById('perf-tags'),
+        perfNotes: document.getElementById('perf-notes'),
+
         // State
         songs: [],
         performanceSetlistId: null,
@@ -35,15 +51,65 @@ document.addEventListener('DOMContentLoaded', () => {
         autoscrollDelay: Number(localStorage.getItem('autoscrollDelay')) || 3,
         resizeObserver: null,
 
+        editMode: localStorage.getItem('perfEditMode') || 'readonly',
+        chordMode: localStorage.getItem('perfChordMode') || 'both',
+
         fontSize: 32, // default value; will set per song
         perSongFontSizes: JSON.parse(localStorage.getItem('perSongFontSizes') || '{}'),
         minFontSize: 16,
         maxFontSize: 72,
         fontSizeStep: 1,
 
+        normalizeSectionLabels(text='') {
+          const keys = ['intro','verse','prechorus','chorus','bridge','outro','hook','refrain','coda','solo','interlude','ending','breakdown','tag'];
+          return text.split(/\r?\n/).map(line=>{
+            const t=line.trim(); if(!t) return line;
+            const m=t.match(/^[\*\s\-_=~`]*[\(\[\{]?\s*([^\]\)\}]+?)\s*[\)\]\}]?[\*\s\-_=~`]*:?$/);
+            if(!m) return line;
+            const label=m[1].trim(); const norm=label.toLowerCase().replace(/[^a-z]/g,'');
+            if(keys.some(k=>norm.startsWith(k))){
+              const formatted=label.replace(/\s+/g,' ').replace(/(^|\s)\S/g,c=>c.toUpperCase());
+              return `[${formatted}]`;
+            }
+            return line;
+          }).join('\n');
+        },
+        cleanText(text=''){ return text
+          .replace(/\r\n/g,'\n').replace(/\n{3,}/g,'\n\n')
+          .replace(/[ \t]+$/gm,'').replace(/^\s+|\s+$/g,'')
+          .replace(/^(Verse|Chorus|Bridge|Outro)[^\n]*$/gmi,'[$1]')
+          .replace(/^#+\s*/gm,'').replace(/```[\s\S]*?```/g,'')
+          .trim();
+        },
+        stripTitleLine(lyrics, title){
+          const lines=lyrics.split('\n'); const norm=(title||'').trim().toLowerCase();
+          if(lines.length && lines[0].trim().toLowerCase()===norm){
+            lines.shift(); if(lines[0]?.trim()==='') lines.shift();
+          }
+          return lines.join('\n');
+        },
+        splitChordLyric(lyrics='', chords=''){
+          const L=lyrics.split('\n'); const C=chords.split('\n');
+          const max=Math.max(L.length,C.length);
+          while(C.length<max) C.push('');
+          while(L.length<max) L.push('');
+          return {L,C};
+        },
+        compactBlankLines(text=''){
+          const out=[]; let prevEmpty=false;
+          for(const line of text.split('\n')){
+            const empty=line.trim()==='';
+            if(!(empty && prevEmpty)) out.push(line);
+            prevEmpty = empty;
+          }
+          return out.join('\n');
+        },
+
         // Initialize
         init() {
             this.loadData();
+            if (this.perfEditModeSelect) this.perfEditModeSelect.value = this.editMode;
+            if (this.perfChordModeSelect) this.perfChordModeSelect.value = this.chordMode;
             this.setupEventListeners();
             this.loadPerformanceState();
             this.displayCurrentPerformanceSong();
@@ -169,6 +235,46 @@ document.addEventListener('DOMContentLoaded', () => {
             this.lyricsDisplay.addEventListener('scroll', () => this.updateScrollButtonsVisibility());
             this.lyricsDisplay.addEventListener('touchstart', () => this.stopAutoScroll());
             this.lyricsDisplay.addEventListener('mousedown', () => this.stopAutoScroll());
+
+            this.perfMenuBtn?.addEventListener('click', ()=> this.perfMenuModal.style.display='block');
+            this.perfMenuClose?.addEventListener('click', ()=> this.perfMenuModal.style.display='none');
+
+            this.perfEditModeSelect?.addEventListener('change', (e)=>{
+              this.editMode = e.target.value;
+              localStorage.setItem('perfEditMode', this.editMode);
+              this.applyEditMode();
+            });
+
+            this.perfChordModeSelect?.addEventListener('change', (e)=>{
+              this.chordMode = e.target.value;
+              localStorage.setItem('perfChordMode', this.chordMode);
+              this.displayCurrentPerformanceSong();
+            });
+
+            this.perfNormalizeBtn?.addEventListener('click', ()=>{
+              this.normalizeCurrentSong();
+            });
+
+            this.perfMetadataBtn?.addEventListener('click', ()=>{
+              this.openMetadata();
+            });
+
+            this.perfMetadataSave?.addEventListener('click', ()=>{
+              this.saveMetadata();
+              this.perfMetadataModal.style.display='none';
+              this.updateHeaderMetaLine();
+            });
+
+            this.perfMetadataClose?.addEventListener('click', ()=>{
+              this.perfMetadataModal.style.display='none';
+            });
+
+            document.addEventListener('keydown', (e)=>{
+              if(e.key==='Escape'){
+                if(this.perfMenuModal?.style.display==='block') this.perfMenuModal.style.display='none';
+                if(this.perfMetadataModal?.style.display==='block') this.perfMetadataModal.style.display='none';
+              }
+            });
         },
 
         // Display current song
@@ -195,10 +301,12 @@ document.addEventListener('DOMContentLoaded', () => {
                 <div class="song-progress">${songNumber} / ${totalSongs}</div>
             `;
 		    
-	    this.lyricsDisplay.textContent = lines.join('\n');
+            song.lyrics = lines.join('\n');
+            this.renderLyrics();
+            this.updateHeaderMetaLine();
 
-	// Restore per-song font size if present, else use last-used or default
-	    let fs = this.perSongFontSizes[song.id];
+        // Restore per-song font size if present, else use last-used or default
+            let fs = this.perSongFontSizes[song.id];
 	    if (typeof fs !== 'number') {
 	    // fallback to previous fontSize or default
 	         fs = this.fontSize || 32;
@@ -211,6 +319,186 @@ document.addEventListener('DOMContentLoaded', () => {
             this.stopAutoScroll();
             this.updateAutoScrollButton();
             this.autoScrollBtn.blur();
+        },
+
+        renderLyrics(){
+          const song = this.performanceSongs[this.currentPerformanceSongIndex];
+          if(!song) return;
+
+          const title = song.title || '';
+          const lyricsNorm = this.normalizeSectionLabels( this.cleanText( this.stripTitleLine(song.lyrics||'', title) ) );
+          const chordsClean = this.cleanText(song.chords||'');
+          const {L, C} = this.splitChordLyric(lyricsNorm, chordsClean);
+
+          this.lyricsDisplay.innerHTML = '';
+          const frag = document.createDocumentFragment();
+
+          let currentSection = null;
+          for(let i=0;i<L.length;i++){
+            const line = L[i]||'';
+
+            if(/^\[.+\]$/.test(line.trim())){
+              const section = document.createElement('div');
+              section.className='section';
+              const header = document.createElement('div');
+              header.className='lyrics-line section-label';
+              const label = document.createElement('span');
+              label.className='section-label-text';
+              label.textContent=line.trim();
+              header.appendChild(label);
+              section.appendChild(header);
+              frag.appendChild(section);
+              currentSection = document.createElement('div');
+              currentSection.className='section-content';
+              section.appendChild(currentSection);
+              continue;
+            }
+
+            const group = document.createElement('div');
+            group.className='lyrics-line-group';
+
+            const chordText = C[i]||'';
+            const chordEl = document.createElement('div');
+            chordEl.className='chord-line';
+            chordEl.textContent = chordText;
+
+            const lyricEl = document.createElement('div');
+            lyricEl.className='lyric-text';
+            lyricEl.textContent = line;
+
+            const mode=this.chordMode;
+            chordEl.style.display = (mode==='off'||mode==='lyrics') ? 'none' : 'block';
+            lyricEl.style.display = (mode==='chords') ? 'none' : 'block';
+
+            chordEl.addEventListener('input', ()=> this.persistEditsFromDOM());
+            lyricEl.addEventListener('input', ()=> this.persistEditsFromDOM());
+
+            group.appendChild(chordEl);
+            group.appendChild(lyricEl);
+            (currentSection || frag).appendChild(group);
+          }
+
+          this.lyricsDisplay.appendChild(frag);
+          this.applyEditMode();
+          setTimeout(()=> this.updateScrollButtonsVisibility(), 100);
+        },
+
+        applyEditMode(){
+          const container = this.lyricsDisplay;
+          if(!container) return;
+          container.querySelectorAll('[contenteditable]').forEach(n=> n.setAttribute('contenteditable','false'));
+          if(this.editMode==='readonly') return;
+
+          if(this.editMode==='lyrics' || this.editMode==='both'){
+            container.querySelectorAll('.lyric-text').forEach(n=> n.setAttribute('contenteditable','true'));
+          }
+          if(this.editMode==='chords' || this.editMode==='both'){
+            container.querySelectorAll('.chord-line').forEach(n=> n.setAttribute('contenteditable','true'));
+          }
+        },
+
+        persistEditsFromDOM(){
+          const song = this.performanceSongs[this.currentPerformanceSongIndex];
+          if(!song) return;
+
+          const lyricLines=[]; const chordLines=[];
+          this.lyricsDisplay.querySelectorAll('.section, .lyrics-line-group').forEach(node=>{
+            if(node.classList.contains('section')){
+              const label = node.querySelector('.section-label-text')?.textContent || '';
+              if(label.trim()) lyricLines.push(label.trim());
+              node.querySelectorAll('.lyrics-line-group').forEach(group=>{
+                const chord = group.querySelector('.chord-line')?.textContent ?? '';
+                const lyric = group.querySelector('.lyric-text')?.textContent ?? '';
+                chordLines.push(chord);
+                lyricLines.push(lyric);
+              });
+            } else {
+              const chord = node.querySelector('.chord-line')?.textContent ?? '';
+              const lyric = node.querySelector('.lyric-text')?.textContent ?? '';
+              chordLines.push(chord);
+              lyricLines.push(lyric);
+            }
+          });
+
+          let lyricsOut = this.normalizeSectionLabels( this.compactBlankLines(lyricLines.join('\n')) );
+          let chordsOut = this.compactBlankLines(chordLines.join('\n'));
+
+          song.lyrics = lyricsOut;
+          song.chords = chordsOut;
+          song.lastEditedAt = new Date().toISOString();
+
+          const all = JSON.parse(localStorage.getItem('songs') || '[]');
+          const idx = all.findIndex(s=> s.id===song.id);
+          if(idx!==-1){ all[idx]=song; localStorage.setItem('songs', JSON.stringify(all)); }
+        },
+
+        normalizeCurrentSong(){
+          const song = this.performanceSongs[this.currentPerformanceSongIndex];
+          if(!song) return;
+          let L = this.stripTitleLine(this.cleanText(song.lyrics||''), song.title||'');
+          L = this.normalizeSectionLabels( this.compactBlankLines(L) );
+          let C = this.compactBlankLines( this.cleanText(song.chords||'') );
+          const Ls=L.split('\n'); const Cs=C.split('\n');
+          const max=Math.max(Ls.length,Cs.length);
+          while(Ls.length<max) Ls.push(''); while(Cs.length<max) Cs.push('');
+          song.lyrics = Ls.join('\n');
+          song.chords = Cs.join('\n');
+          song.lastEditedAt = new Date().toISOString();
+          const all = JSON.parse(localStorage.getItem('songs') || '[]');
+          const idx = all.findIndex(s=> s.id===song.id);
+          if(idx!==-1){ all[idx]=song; localStorage.setItem('songs', JSON.stringify(all)); }
+
+          this.displayCurrentPerformanceSong();
+        },
+
+        openMetadata(){
+          const song=this.performanceSongs[this.currentPerformanceSongIndex]; if(!song) return;
+          this.perfKey.value = song.key || '';
+          this.perfTempo.value = song.tempo || 120;
+          this.perfTS.value = song.timeSignature || '4/4';
+          this.perfTags.value = (song.tags||[]).join(', ');
+          this.perfNotes.value = song.notes || '';
+          this.perfMetadataModal.style.display='block';
+        },
+
+        saveMetadata(){
+          const song=this.performanceSongs[this.currentPerformanceSongIndex]; if(!song) return;
+          song.key = this.perfKey.value || '';
+          song.tempo = parseInt(this.perfTempo.value || '120',10);
+          song.timeSignature = this.perfTS.value || '4/4';
+          song.tags = this.perfTags.value.split(',').map(t=>t.trim()).filter(Boolean);
+          song.notes = this.perfNotes.value || '';
+          song.lastEditedAt = new Date().toISOString();
+          const all = JSON.parse(localStorage.getItem('songs') || '[]');
+          const idx = all.findIndex(s=> s.id===song.id);
+          if(idx!==-1){ all[idx]=song; localStorage.setItem('songs', JSON.stringify(all)); }
+        },
+
+        updateHeaderMetaLine(){
+          const song=this.performanceSongs[this.currentPerformanceSongIndex]; if(!song) return;
+          const metaBits=[];
+          if(song.key) metaBits.push(song.key);
+          if(song.tempo) metaBits.push(`${song.tempo} BPM`);
+          if(song.timeSignature && song.timeSignature!=='4/4') metaBits.push(song.timeSignature);
+          let html = metaBits.join(' • ');
+          if(song.notes && song.notes.trim()){
+            html += ` <i id="perf-notes-icon" class="fas fa-info-circle notes-icon" title="Show notes"></i>`;
+          }
+
+          let metaLine = this.performanceSongInfo.querySelector('.song-meta-line');
+          if(!metaLine){
+            metaLine = document.createElement('div');
+            metaLine.className='song-meta-line';
+            this.performanceSongInfo.appendChild(metaLine);
+          }
+          metaLine.innerHTML = html || '';
+
+          const icon = document.getElementById('perf-notes-icon');
+          if(icon){
+            icon.addEventListener('click', ()=>{
+              alert(song.notes || 'No notes');
+            });
+          }
         },
 
         // Font size methods

--- a/style.css
+++ b/style.css
@@ -515,6 +515,10 @@ img, video, iframe {
     pointer-events: auto; /* Ensure it can receive clicks */
 }
 
+.hidden {
+    display: none !important;
+}
+
 /* ========================================
     Song List and Setlist Editor
     ======================================== */


### PR DESCRIPTION
## Summary
- add performance menu with edit and chord mode options, normalization, and song info access
- render chords and lyrics with section headers and persistent editing stored in localStorage
- style new modals and metadata line and provide shared `.hidden` utility

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68ad8ddf6710832ab6cb8ed00296e1bb