### PR TITLE
Fix performance modal stacking and toggling

### DIFF
--- a/performance/performance.css
+++ b/performance/performance.css
@@ -207,7 +207,9 @@
     color: var(--accent-primary, #fff);
 }
 
-#autoscroll-delay-modal {
+#autoscroll-delay-modal,
+#performance-menu-modal,
+#perf-metadata-modal {
     z-index: 20000;
     display: none;
     position: fixed;
@@ -216,15 +218,19 @@
     width: 100vw;
     height: 100vh;
     background: rgba(0,0,0,0.82);
-   -cast-align-items: center;
     justify-content: center;
+    align-items: center;
 }
 
-#autoscroll-delay-modal[style*="display: block"] {
+#autoscroll-delay-modal.is-open,
+#performance-menu-modal.is-open,
+#perf-metadata-modal.is-open {
     display: flex;
 }
 
-#autoscroll-delay-modal .modal-content {
+#autoscroll-delay-modal .modal-content,
+#performance-menu-modal .modal-content,
+#perf-metadata-modal .modal-content {
     position: relative;
     z-index: 20001;
     background: var(--bg-primary, #222);

--- a/performance/performance.html
+++ b/performance/performance.html
@@ -52,7 +52,7 @@
 
 
     <!-- Performance Menu Modal -->
-    <div id="performance-menu-modal" class="modal" style="display:none;">
+    <div id="performance-menu-modal" class="modal">
       <div class="modal-content">
         <h2>Performance Options</h2>
 
@@ -89,7 +89,7 @@
     </div>
 
     <!-- Metadata Panel/Modal -->
-    <div id="perf-metadata-modal" class="modal" style="display:none;">
+    <div id="perf-metadata-modal" class="modal">
       <div class="modal-content">
         <h2>Song Information</h2>
 

--- a/performance/performance.js
+++ b/performance/performance.js
@@ -213,7 +213,7 @@ document.addEventListener('DOMContentLoaded', () => {
             });
             this.autoScrollBtn.addEventListener('click', () => this.toggleAutoScroll());
             this.autoscrollSettingsBtn.addEventListener('click', () => {
-                this.autoscrollDelayModal.style.display = 'block';
+                this.autoscrollDelayModal.classList.add('is-open');
                 this.autoscrollDelaySlider.value = this.autoscrollDelay;
                 this.autoscrollDelayValue.textContent = this.autoscrollDelay + 's';
                 this.autoscrollSpeedSlider.value = this.autoScrollSpeed;
@@ -230,14 +230,14 @@ document.addEventListener('DOMContentLoaded', () => {
                 localStorage.setItem('autoscrollDelay', this.autoscrollDelay);
                 this.autoScrollSpeed = Number(this.autoscrollSpeedSlider.value);
                 localStorage.setItem('autoscrollSpeed', this.autoScrollSpeed);
-                this.autoscrollDelayModal.style.display = 'none';
+                this.autoscrollDelayModal.classList.remove('is-open');
             });
             this.lyricsDisplay.addEventListener('scroll', () => this.updateScrollButtonsVisibility());
             this.lyricsDisplay.addEventListener('touchstart', () => this.stopAutoScroll());
             this.lyricsDisplay.addEventListener('mousedown', () => this.stopAutoScroll());
 
-            this.perfMenuBtn?.addEventListener('click', ()=> this.perfMenuModal.style.display='block');
-            this.perfMenuClose?.addEventListener('click', ()=> this.perfMenuModal.style.display='none');
+            this.perfMenuBtn?.addEventListener('click', ()=> this.perfMenuModal.classList.add('is-open'));
+            this.perfMenuClose?.addEventListener('click', ()=> this.perfMenuModal.classList.remove('is-open'));
 
             this.perfEditModeSelect?.addEventListener('change', (e)=>{
               this.editMode = e.target.value;
@@ -261,18 +261,19 @@ document.addEventListener('DOMContentLoaded', () => {
 
             this.perfMetadataSave?.addEventListener('click', ()=>{
               this.saveMetadata();
-              this.perfMetadataModal.style.display='none';
+              this.perfMetadataModal.classList.remove('is-open');
               this.updateHeaderMetaLine();
             });
 
             this.perfMetadataClose?.addEventListener('click', ()=>{
-              this.perfMetadataModal.style.display='none';
+              this.perfMetadataModal.classList.remove('is-open');
             });
 
             document.addEventListener('keydown', (e)=>{
               if(e.key==='Escape'){
-                if(this.perfMenuModal?.style.display==='block') this.perfMenuModal.style.display='none';
-                if(this.perfMetadataModal?.style.display==='block') this.perfMetadataModal.style.display='none';
+                if(this.autoscrollDelayModal?.classList.contains('is-open')) this.autoscrollDelayModal.classList.remove('is-open');
+                if(this.perfMenuModal?.classList.contains('is-open')) this.perfMenuModal.classList.remove('is-open');
+                if(this.perfMetadataModal?.classList.contains('is-open')) this.perfMetadataModal.classList.remove('is-open');
               }
             });
         },
@@ -458,7 +459,7 @@ document.addEventListener('DOMContentLoaded', () => {
           this.perfTS.value = song.timeSignature || '4/4';
           this.perfTags.value = (song.tags||[]).join(', ');
           this.perfNotes.value = song.notes || '';
-          this.perfMetadataModal.style.display='block';
+          this.perfMetadataModal.classList.add('is-open');
         },
 
         saveMetadata(){

--- a/style.css
+++ b/style.css
@@ -633,7 +633,7 @@ img, video, iframe {
 .modal {
     display: none;
     position: fixed;
-    z-index: 1;
+    z-index: 20010;
     left: 0;
     top: 0;
     width: 100%;
@@ -658,12 +658,16 @@ img, video, iframe {
 .modal {
     display: none;
     position: fixed;
-    z-index: 1;
+    z-index: 20010;
     left: 0; top: 0; width: 100%; height: 100%;
     overflow: auto;
     background-color: rgba(0,0,0,0.6);
     justify-content: center;
     align-items: center;
+}
+
+.modal.is-open {
+    display: flex;
 }
 
 .modal-content {


### PR DESCRIPTION
## Summary
- Ensure global modals overlay above performance mode and open via `.is-open`
- Add z-index and flex centering for performance menu and metadata modals
- Toggle performance modals with class helpers and Escape-key handling

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68add600dbec832aaf1107266c787f3d