### PR TITLE
Add sticky footer controls and fix modal stacking

### DIFF
--- a/performance/performance.css
+++ b/performance/performance.css
@@ -40,7 +40,25 @@
     margin-right: 0.35em;
 }
 
-.performance-controls .icon-btn {
+.performance-footer {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    height: 56px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5em;
+    padding: 0.45em 0.65em;
+    background-color: var(--bg-secondary);
+    border-top: 1px solid var(--border);
+    z-index: 2025;
+    transition: background-color var(--transition-speed), border-color var(--transition-speed);
+}
+
+.performance-controls .icon-btn,
+.performance-footer .icon-btn {
     background: var(--bg-tertiary, #1a1a1a);
     color: var(--accent-primary, #fff);
     border: none;
@@ -59,7 +77,9 @@
 }
 
 .performance-controls .icon-btn:hover,
-.performance-controls .icon-btn:focus {
+.performance-controls .icon-btn:focus,
+.performance-footer .icon-btn:hover,
+.performance-footer .icon-btn:focus {
     background: var(--accent-hover, #fff);
     color: var(--accent-primary, #222);
     box-shadow: 0 2px 16px var(--accent-glow, #fff8);
@@ -68,7 +88,9 @@
 }
 
 .performance-controls .icon-btn.danger,
-.performance-controls .icon-btn[title*="Exit"] {
+.performance-controls .icon-btn[title*="Exit"],
+.performance-footer .icon-btn.danger,
+.performance-footer .icon-btn[title*="Exit"] {
     background: var(--danger, #ef4444);
     color: #fff;
     box-shadow: 0 2px 10px rgba(255,0,0,0.10);
@@ -77,17 +99,24 @@
 .performance-controls .icon-btn.danger:hover,
 .performance-controls .icon-btn.danger:focus,
 .performance-controls .icon-btn[title*="Exit"]:hover,
-.performance-controls .icon-btn[title*="Exit"]:focus {
+.performance-controls .icon-btn[title*="Exit"]:focus,
+.performance-footer .icon-btn.danger:hover,
+.performance-footer .icon-btn.danger:focus,
+.performance-footer .icon-btn[title*="Exit"]:hover,
+.performance-footer .icon-btn[title*="Exit"]:focus {
     background: #fff;
     color: var(--danger, #ef4444);
     box-shadow: 0 0 20px 2px var(--danger, #ef4444), 0 0 8px var(--accent-glow, #fff3);
 }
 
-.performance-controls .icon-btn:active {
+
+.performance-controls .icon-btn:active,
+.performance-footer .icon-btn:active {
     transform: scale(0.96);
 }
 
-.performance-controls .icon-btn i {
+.performance-controls .icon-btn i,
+.performance-footer .icon-btn i {
     font-size: 1.06em;
 }
 
@@ -165,11 +194,11 @@
 }
 
 .scroll-to-top-btn {
-    bottom: 120px;
+    bottom: 176px;
 }
 
 .auto-scroll-btn {
-    bottom: 52px;
+    bottom: 108px;
     display: flex;
 }
 
@@ -210,29 +239,14 @@
 #autoscroll-delay-modal,
 #performance-menu-modal,
 #perf-metadata-modal {
-    z-index: 20000;
-    display: none;
-    position: fixed;
-    left: 0;
-    top: 0;
-    width: 100vw;
-    height: 100vh;
+    z-index: 20050;
     background: rgba(0,0,0,0.82);
-    justify-content: center;
-    align-items: center;
-}
-
-#autoscroll-delay-modal.is-open,
-#performance-menu-modal.is-open,
-#perf-metadata-modal.is-open {
-    display: flex;
 }
 
 #autoscroll-delay-modal .modal-content,
 #performance-menu-modal .modal-content,
 #perf-metadata-modal .modal-content {
-    position: relative;
-    z-index: 20001;
+    z-index: 20051;
     background: var(--bg-primary, #222);
 }
 
@@ -281,18 +295,19 @@
       transition: background 0.22s, opacity 0.14s, color 0.14s;
     }
     .scroll-to-top-btn {
-      bottom: 100px;
-    } 
+      bottom: 156px;
+    }
 
     .auto-scroll-btn {
-      bottom: 52px;
+      bottom: 108px;
       display: flex;
     }
-    
-    .performance-controls .icon-btn {
-    width: 2em;
-    height: 2em;
-    font-size: 1rem;
+
+    .performance-controls .icon-btn,
+    .performance-footer .icon-btn {
+      width: 2em;
+      height: 2em;
+      font-size: 1rem;
    }
 }
 

--- a/performance/performance.html
+++ b/performance/performance.html
@@ -19,20 +19,18 @@
             	<div class="performance-controls">
 	    <button id="prev-song-btn" class="nav-arrow left"><i class="fas fa-chevron-left"></i></button>
 	    <button id="next-song-btn" class="nav-arrow right"><i class="fas fa-chevron-right"></i></button>
-	    <!-- FONT SIZE BUTTONS -->
-	    <button id="decrease-font-btn" class="icon-btn" title="Smaller Font"><i class="fas fa-minus"></i></button>
-	    <span id="font-size-display" style="min-width:2.2em;text-align:center;font-size:1.03em;">32px</span>
-	    <button id="increase-font-btn" class="icon-btn" title="Larger Font"><i class="fas fa-plus"></i></button>
-            <button id="autoscroll-settings-btn" class="icon-btn" title="Autoscroll Settings"><i class="fas fa-cog"></i></button>
-            <button id="perf-menu-btn" class="icon-btn" title="Performance Menu">
-              <i class="fas fa-ellipsis-h"></i>
-            </button>
-            <button id="theme-toggle-btn" class="icon-btn theme-toggle-btn" title="Toggle Theme"><i class="fas fa-adjust"></i></button>
-            <button id="exit-performance-btn" class="icon-btn danger" title="Exit Performance"><i class="fas fa-times"></i></button>
         </div>
         </div>
         <div id="lyrics-display" class="lyrics-container"></div>
-        
+        <div class="performance-footer">
+            <button id="footer-decrease-font-btn" class="icon-btn" title="Smaller Font"><i class="fas fa-minus"></i></button>
+            <span id="footer-font-size-display" style="min-width:2.2em;text-align:center;font-size:1.03em;">32px</span>
+            <button id="footer-increase-font-btn" class="icon-btn" title="Larger Font"><i class="fas fa-plus"></i></button>
+            <button id="footer-autoscroll-settings-btn" class="icon-btn" title="Autoscroll Settings"><i class="fas fa-cog"></i></button>
+            <button id="footer-perf-menu-btn" class="icon-btn" title="Performance Menu"><i class="fas fa-ellipsis-h"></i></button>
+            <button id="footer-theme-toggle-btn" class="icon-btn theme-toggle-btn" title="Toggle Theme"><i class="fas fa-adjust"></i></button>
+            <button id="footer-exit-performance-btn" class="icon-btn danger" title="Exit Performance"><i class="fas fa-times"></i></button>
+        </div>
     </div>
     <div id="autoscroll-delay-modal" class="modal">
         <div class="modal-content">

--- a/performance/performance.js
+++ b/performance/performance.js
@@ -7,13 +7,16 @@ document.addEventListener('DOMContentLoaded', () => {
         decreaseFontBtn: document.getElementById('decrease-font-btn'),
         increaseFontBtn: document.getElementById('increase-font-btn'),
         fontSizeDisplay: document.getElementById('font-size-display'),
-        toggleThemeBtn: document.getElementById('theme-toggle-btn'),
-        exitPerformanceBtn: document.getElementById('exit-performance-btn'),
+        footerDecreaseFontBtn: document.getElementById('footer-decrease-font-btn'),
+        footerIncreaseFontBtn: document.getElementById('footer-increase-font-btn'),
+        footerFontSizeDisplay: document.getElementById('footer-font-size-display'),
+        toggleThemeBtn: document.getElementById('footer-theme-toggle-btn') || document.getElementById('theme-toggle-btn'),
+        exitPerformanceBtn: document.getElementById('footer-exit-performance-btn') || document.getElementById('exit-performance-btn'),
         prevSongBtn: document.getElementById('prev-song-btn'),
         nextSongBtn: document.getElementById('next-song-btn'),
         scrollToTopBtn: document.getElementById('scroll-to-top-btn'),
         autoScrollBtn: document.getElementById('auto-scroll-btn'),
-        autoscrollSettingsBtn: document.getElementById('autoscroll-settings-btn'),
+        autoscrollSettingsBtn: document.getElementById('footer-autoscroll-settings-btn') || document.getElementById('autoscroll-settings-btn'),
         autoscrollDelayModal: document.getElementById('autoscroll-delay-modal'),
         autoscrollDelaySlider: document.getElementById('autoscroll-delay-slider'),
         autoscrollDelayValue: document.getElementById('autoscroll-delay-value'),
@@ -21,7 +24,7 @@ document.addEventListener('DOMContentLoaded', () => {
         autoscrollSpeedValue: document.getElementById('autoscroll-speed-value'),
         closeAutoscrollDelayModal: document.getElementById('close-autoscroll-delay-modal'),
 
-        perfMenuBtn: document.getElementById('perf-menu-btn'),
+        perfMenuBtn: document.getElementById('footer-perf-menu-btn') || document.getElementById('perf-menu-btn'),
         perfMenuModal: document.getElementById('performance-menu-modal'),
         perfMenuClose: document.getElementById('perf-menu-close'),
         perfEditModeSelect: document.getElementById('perf-edit-mode'),
@@ -201,18 +204,20 @@ document.addEventListener('DOMContentLoaded', () => {
         // Setup event listeners
         setupEventListeners() {
             // FONT SIZE BUTTONS
-            this.decreaseFontBtn.addEventListener('click', () => this.adjustFontSize(-this.fontSizeStep));
-            this.increaseFontBtn.addEventListener('click', () => this.adjustFontSize(this.fontSizeStep));
+            this.decreaseFontBtn?.addEventListener('click', () => this.adjustFontSize(-this.fontSizeStep));
+            this.increaseFontBtn?.addEventListener('click', () => this.adjustFontSize(this.fontSizeStep));
+            this.footerDecreaseFontBtn?.addEventListener('click', () => this.adjustFontSize(-this.fontSizeStep));
+            this.footerIncreaseFontBtn?.addEventListener('click', () => this.adjustFontSize(this.fontSizeStep));
 
-            this.toggleThemeBtn.addEventListener('click', () => this.handlePerformanceThemeToggle());
-            this.exitPerformanceBtn.addEventListener('click', () => this.exitPerformanceMode());
+            this.toggleThemeBtn?.addEventListener('click', () => this.handlePerformanceThemeToggle());
+            this.exitPerformanceBtn?.addEventListener('click', () => this.exitPerformanceMode());
             this.prevSongBtn.addEventListener('click', () => this.navigatePerformanceSong(-1));
             this.nextSongBtn.addEventListener('click', () => this.navigatePerformanceSong(1));
             this.scrollToTopBtn.addEventListener('click', () => {
                 this.lyricsDisplay.scrollTo({ top: 0, behavior: 'smooth' });
             });
             this.autoScrollBtn.addEventListener('click', () => this.toggleAutoScroll());
-            this.autoscrollSettingsBtn.addEventListener('click', () => {
+            this.autoscrollSettingsBtn?.addEventListener('click', () => {
                 this.autoscrollDelayModal.classList.add('is-open');
                 this.autoscrollDelaySlider.value = this.autoscrollDelay;
                 this.autoscrollDelayValue.textContent = this.autoscrollDelay + 's';
@@ -520,6 +525,9 @@ document.addEventListener('DOMContentLoaded', () => {
             }
             if (this.fontSizeDisplay) {
                 this.fontSizeDisplay.textContent = `${Math.round(this.fontSize)}px`;
+            }
+            if (this.footerFontSizeDisplay) {
+                this.footerFontSizeDisplay.textContent = `${Math.round(this.fontSize)}px`;
             }
             setTimeout(() => this.updateScrollButtonsVisibility(), 100);
         },

--- a/style.css
+++ b/style.css
@@ -634,32 +634,8 @@ img, video, iframe {
     display: none;
     position: fixed;
     z-index: 20010;
-    left: 0;
-    top: 0;
-    width: 100%;
-    height: 100%;
-    overflow: auto;
-    background-color: rgba(0,0,0,0.6); /* Slightly darker overlay for modals */
-}
-
-.modal-content {
-    background-color: var(--bg-primary); /* Modal content uses primary background */
-    margin: 15% auto;
-    padding: 20px;
-    border: 1px solid var(--border); /* Modal borders use main border */
-    width: 80%;
-    max-width: 500px;
-    border-radius: var(--border-radius-base); /* Using base border radius */
-    box-shadow: var(--shadow-lg); /* Larger shadow for modals */
-    transition: background-color var(--transition-speed), border-color var(--transition-speed), box-shadow var(--transition-speed);
-}
-
-/* Modal Style Fixes & Neon Glow */
-.modal {
-    display: none;
-    position: fixed;
-    z-index: 20010;
-    left: 0; top: 0; width: 100%; height: 100%;
+    left: 0; top: 0;
+    width: 100%; height: 100%;
     overflow: auto;
     background-color: rgba(0,0,0,0.6);
     justify-content: center;

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'hill-rd-setlist-manager-v1';
+const CACHE_NAME = 'hill-rd-setlist-manager-v2';
 const urlsToCache = [
     '/',
     '/index.html',
@@ -11,7 +11,7 @@ const urlsToCache = [
     '/assets/icons/icon-192x192.png',
     '/assets/icons/icon-512x512.png',
     '/assets/images/mylogo.png',
-    'lib/mammoth.browser.min.js',
+    '/lib/mammoth.browser.min.js',
     'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css',
     'https://cdn.jsdelivr.net/npm/fuse.js@6.6.2/dist/fuse.min.js'
 ];


### PR DESCRIPTION
## Summary
- Add performance footer with font-size controls and quick actions for thumb-friendly access
- Reposition floating action buttons and ensure modals stack above the performance overlay
- Clean up modal styles and bump service worker cache version

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68adde45c924832a821fe9ed17cad549