### PR TITLE
Refactor performance layout and remember per-song settings

### DIFF
--- a/performance/performance.html
+++ b/performance/performance.html
@@ -16,20 +16,20 @@
     <div id="performance-mode" class="performance-mode-overlay" style="display: flex;">
         <div class="performance-header">
             <div id="performance-song-info" class="song-info"></div>
-            	<div class="performance-controls">
-	    <button id="prev-song-btn" class="nav-arrow left"><i class="fas fa-chevron-left"></i></button>
-	    <button id="next-song-btn" class="nav-arrow right"><i class="fas fa-chevron-right"></i></button>
+            <div class="performance-controls">
+                <button id="autoscroll-settings-btn" class="icon-btn" title="Autoscroll Settings"><i class="fas fa-cog"></i></button>
+                <button id="perf-menu-btn" class="icon-btn" title="Performance Menu"><i class="fas fa-ellipsis-h"></i></button>
+                <button id="theme-toggle-btn" class="icon-btn theme-toggle-btn" title="Toggle Theme"><i class="fas fa-adjust"></i></button>
+                <button id="exit-performance-btn" class="icon-btn danger" title="Exit Performance"><i class="fas fa-times"></i></button>
+            </div>
         </div>
-        </div>
+        <button id="prev-song-btn" class="nav-arrow left"><i class="fas fa-chevron-left"></i></button>
+        <button id="next-song-btn" class="nav-arrow right"><i class="fas fa-chevron-right"></i></button>
         <div id="lyrics-display" class="lyrics-container"></div>
         <div class="performance-footer">
             <button id="footer-decrease-font-btn" class="icon-btn" title="Smaller Font"><i class="fas fa-minus"></i></button>
             <span id="footer-font-size-display" style="min-width:2.2em;text-align:center;font-size:1.03em;">32px</span>
             <button id="footer-increase-font-btn" class="icon-btn" title="Larger Font"><i class="fas fa-plus"></i></button>
-            <button id="footer-autoscroll-settings-btn" class="icon-btn" title="Autoscroll Settings"><i class="fas fa-cog"></i></button>
-            <button id="footer-perf-menu-btn" class="icon-btn" title="Performance Menu"><i class="fas fa-ellipsis-h"></i></button>
-            <button id="footer-theme-toggle-btn" class="icon-btn theme-toggle-btn" title="Toggle Theme"><i class="fas fa-adjust"></i></button>
-            <button id="footer-exit-performance-btn" class="icon-btn danger" title="Exit Performance"><i class="fas fa-times"></i></button>
         </div>
     </div>
     <div id="autoscroll-delay-modal" class="modal">


### PR DESCRIPTION
## Summary
- Move autoscroll, menu, theme, and exit controls into header; keep font sizing centered in footer
- Persist font size and autoscroll preferences per song
- Fix autoscroll settings modal to save per-song values

## Testing
- `node --check performance/performance.js`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68ade2617a60832aaf105dcba5d3da73