### PR TITLE
Improve chord editing and autoscroll settings display

### DIFF
--- a/performance/performance.css
+++ b/performance/performance.css
@@ -336,5 +336,11 @@
 .performance-header .song-meta-line .notes-icon:hover { opacity: 1; }
 
 .lyrics-line-group { margin-bottom: 0.35em; }
-.chord-line { white-space: pre; font-size: 0.85em; color: var(--accent-secondary, #ccc); }
+.lyric-text,
+.chord-line { text-align: left; }
+.chord-line {
+  white-space: pre;
+  font-size: 0.75em;
+  color: var(--text-muted, #888);
+}
 .section-label { margin-top: 0.6em; font-weight: bold; }

--- a/performance/performance.js
+++ b/performance/performance.js
@@ -354,7 +354,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
           const title = song.title || '';
           const lyricsNorm = this.normalizeSectionLabels( this.cleanText( this.stripTitleLine(song.lyrics||'', title) ) );
-          const chordsClean = this.cleanText(song.chords||'');
+          const chordsClean = this.compactBlankLines((song.chords||'').replace(/\r\n/g,'\n'));
           const {L, C} = this.splitChordLyric(lyricsNorm, chordsClean);
 
           this.lyricsDisplay.innerHTML = '';
@@ -464,7 +464,7 @@ document.addEventListener('DOMContentLoaded', () => {
           if(!song) return;
           let L = this.stripTitleLine(this.cleanText(song.lyrics||''), song.title||'');
           L = this.normalizeSectionLabels( this.compactBlankLines(L) );
-          let C = this.compactBlankLines( this.cleanText(song.chords||'') );
+          let C = this.compactBlankLines((song.chords||'').replace(/\r\n/g,'\n'));
           const Ls=L.split('\n'); const Cs=C.split('\n');
           const max=Math.max(Ls.length,Cs.length);
           while(Ls.length<max) Ls.push(''); while(Cs.length<max) Cs.push('');

--- a/style.css
+++ b/style.css
@@ -1202,15 +1202,6 @@ img, video, iframe {
 
 #autoscroll-delay-modal {
   z-index: 20000 !important;
-  display: none;  /* Still controlled by JS */
-  position: fixed !important;
-  left: 0; top: 0; width: 100vw; height: 100vh;
-  background: rgba(0,0,0,0.82) !important;
-  align-items: center;
-  justify-content: center;
-}
-#autoscroll-delay-modal[style*="display: block"] {
-  display: flex !important;
 }
 #autoscroll-delay-modal .modal-content {
   position: relative;


### PR DESCRIPTION
## Summary
- Style chord lines with smaller muted text and left alignment
- Preserve chord spacing and alignments when rendering and normalizing
- Fix autoscroll settings modal so it opens via `is-open` class

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68ade785c294832ab3636336377ef299